### PR TITLE
Migration Info

### DIFF
--- a/Lagrange.OneBot/Extensions/HostApplicationBuilderExtension.cs
+++ b/Lagrange.OneBot/Extensions/HostApplicationBuilderExtension.cs
@@ -5,6 +5,7 @@ using Lagrange.OneBot.Core.Network;
 using Lagrange.OneBot.Core.Network.Service;
 using Lagrange.OneBot.Core.Notify;
 using Lagrange.OneBot.Core.Operation;
+using Lagrange.OneBot.Database;
 using Lagrange.OneBot.Message;
 using Lagrange.OneBot.Utility;
 using Microsoft.Extensions.Configuration;
@@ -86,7 +87,13 @@ public static class HostApplicationBuilderExtension
                 if (!Directory.Exists(prefix)) Directory.CreateDirectory(prefix);
                 string path = Path.GetFullPath(Path.Join(prefix, ".realm"));
 
-                return new RealmConfiguration(path);
+                return new RealmConfiguration(path)
+                {
+                    // Increase one version above upstream to ensure migration
+                    // When adding or subtracting MessageRecord fields, you need to increase 1
+                    // In addition to this case, you need to write `MigrationCallback`
+                    SchemaVersion = 2,
+                };
             })
             .AddSingleton<RealmHelper>()
 


### PR DESCRIPTION
Increase [one version](https://github.com/sisi0318/Lagrange.Core/blob/10c0d7b5c0fa91f5955cf7c9936833c421e8f710/Lagrange.OneBot/Extensions/HostApplicationBuilderExtension.cs#L95) above upstream to ensure migration
When adding or subtracting MessageRecord fields, you need to increase 1
In addition to this case, you need to write `MigrationCallback`